### PR TITLE
Cathy/bugfixdeps

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ options for how to install ffmpeg:
 Next, run the following command to install a few additional dependencies:
 
 ```
-pip install .[demos]
+pip install ".[demos]"
 ```
 
 ## Troubleshooting

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
     install_requires=[
         "absl-py",
         "dm_env",
-        "dm_env_rpc",
+        "dm_env_rpc==1.0.2",
         "docker",
         "grpcio",
         "numpy",
@@ -45,7 +45,7 @@ setup(
         "setuptools",
         "shapely",
     ],
-    extras_require={"demos": ["matplotlib"]},
+    extras_require={"demos": ["matplotlib", "jupyter"]},
     classifiers=[
         "Development Status :: 4 - Beta",
         "Intended Audience :: Developers",


### PR DESCRIPTION
Bugfix to pin dm_env_rpc version to 1.0.2. Otherwise, on 1.0.4, get the following error when trying to load environment:
```
>>> import dm_construction
>>> env = dm_construction.gen_environment("covering", difficulty=0)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: module 'dm_construction' has no attribute 'gen_environment'
>>> env = dm_construction.get_environment("covering", difficulty=0)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/cathy/code/dm_construction/dm_construction/_environment_factory.py", line 73, in get_environment
    unity_environment = get_unity_environment(backend=unity_backend)
  File "/Users/cathy/code/dm_construction/dm_construction/_environment_factory.py", line 51, in get_unity_environment
    return environment.UnityConstructionEnv(loader=_LOADERS[backend], **config)
  File "/Users/cathy/code/dm_construction/dm_construction/unity/environment.py", line 222, in __init__
    self._load_env(loader)
  File "/Users/cathy/code/dm_construction/dm_construction/unity/environment.py", line 338, in _load_env
    config_json, observations, self._version, local_path=self._local_path)
  File "/Users/cathy/code/dm_construction/dm_construction/unity/docker.py", line 285, in loader
    container=container)
  File "/Users/cathy/code/dm_construction/dm_construction/unity/docker.py", line 55, in __init__
    super().__init__(connection, specs, observations, nested_tensors=False)
  File "/Users/cathy/miniconda3/lib/python3.7/site-packages/dm_env_rpc/v1/dm_env_adaptor.py", line 74, in __init__
    self._observation_specs = spec_manager.SpecManager(specs.observations)
  File "/Users/cathy/miniconda3/lib/python3.7/site-packages/dm_env_rpc/v1/spec_manager.py", line 53, in __init__
    f'"{spec.name}" shape has > 1 variable length dimension. '
ValueError: "ObserverCamera" shape has > 1 variable length dimension. Spec:
name: "ObserverCamera"
shape: -1
shape: -1
shape: 3
dtype: UINT8
```