### PR TITLE
Cnn encoder

### DIFF
--- a/experiments/model.py
+++ b/experiments/model.py
@@ -9,6 +9,37 @@ from torch.distributions.normal import Normal
 import dm_construction
 
 
+class CNNEncoder(nn.Module):
+    """Process RGB image observations.
+    """
+    def __init__(self, obs_dim,):
+        super().__init__()
+        self.height, self.width, self.channels = obs_dim
+
+        # Define image embedding
+        self.image_conv = nn.Sequential(
+            nn.Conv2d(self.channels, 16, (2, 2)),
+            nn.ReLU(),
+            nn.MaxPool2d((2, 2)),
+            nn.Conv2d(16, 32, (2, 2)),
+            nn.ReLU(),
+            nn.Conv2d(32, 64, (2, 2)),
+            nn.ReLU()
+        )
+
+    @property
+    def image_embedding_size(self):
+        return ((self.height-1)//2-2)*((self.width-1)//2-2)*64
+
+    def forward(self, obs):
+        x = torch.tensor(obs, dtype=torch.float32)
+        x = x.unsqueeze(0)  # TODO: change when batch size > 1
+        x = x.transpose(1, 3).transpose(2, 3)
+        x = self.image_conv(x)
+        x = x.reshape(x.shape[0], -1)
+        return x
+
+
 class RNNEncoder(nn.Module):
     """
     Preprocess state observations, a sequence of object state vectors,
@@ -34,9 +65,9 @@ class RNNEncoder(nn.Module):
         output, hn = self.gru(obs_nodes)
         # output shape: (seq_len, batch, num_directions * hidden_size)
         # hn shape: (num_layers * num_directions, batch, hidden_size)
-        return output, hn
+        return hn
 
-    
+
 class MLPGaussianActorCritic(nn.Module):
     """
     Actor-Critic with dual policy and value heads.
@@ -53,20 +84,33 @@ class MLPGaussianActorCritic(nn.Module):
     Value function:
     An MLP with 2 hidden layers of size 256 units.
     """
-    def __init__(self, obs_dim, act_dim, rnn_hidden_size=256, mlp_hidden_size=256):
+    def __init__(self,
+                 obs_dim,
+                 act_dim,
+                 ob_type,
+                 mlp_hidden_size=256,
+                 encoder_embedding_size=None,):
         super().__init__()
-        self.rnn_hidden_size = rnn_hidden_size
-        self.mlp_hidden_size = mlp_hidden_size
 
-        # RNN encoder
-        self.rnn_encoder = RNNEncoder(obs_dim, rnn_hidden_size)
+        if ob_type == "graph":
+            self.encoder = RNNEncoder(obs_dim, encoder_embedding_size)
+            self.encoder_embedding_size = encoder_embedding_size
+        elif ob_type == "image":
+            if encoder_embedding_size is not None:
+                print("Ignore user input embedding size for CNN")
+            self.encoder = CNNEncoder(obs_dim)
+            self.encoder_embedding_size = self.encoder.image_embedding_size
+        else:
+            raise ValueError
+
+        self.mlp_hidden_size = mlp_hidden_size
 
         log_std = -0.5 * np.ones(act_dim, dtype=np.float32)
         self.log_std = torch.nn.Parameter(torch.as_tensor(log_std))
 
         # MLP core
         self.mu_net = nn.Sequential(
-            nn.Linear(rnn_hidden_size, mlp_hidden_size),
+            nn.Linear(self.encoder_embedding_size, mlp_hidden_size),
             nn.ReLU(),
             nn.Linear(mlp_hidden_size, mlp_hidden_size),
             nn.ReLU(),
@@ -79,7 +123,7 @@ class MLPGaussianActorCritic(nn.Module):
 
         # Critic
         self.v = nn.Sequential(
-            nn.Linear(rnn_hidden_size, mlp_hidden_size),
+            nn.Linear(self.encoder_embedding_size, mlp_hidden_size),
             nn.ReLU(),
             nn.Linear(mlp_hidden_size, mlp_hidden_size),
             nn.ReLU(),
@@ -90,9 +134,9 @@ class MLPGaussianActorCritic(nn.Module):
         # Produce action distributions for given observations, and 
         # optionally compute the log likelihood of given actions under
         # those distributions.
-        _, hn = self.rnn_encoder(obs)
-        pi = self._distribution(hn)
-        v = torch.squeeze(self.v(hn), -1)
+        obs_emb = self.encoder(obs)
+        pi = self._distribution(obs_embed)
+        v = torch.squeeze(self.v(obs_embed), -1)
         logp_a = None
         if act is not None:
             logp_a = self._log_prob_from_distribution(pi, act)
@@ -128,31 +172,50 @@ def wrapper_type_from_ac_spec(ac_spec):
         raise ValueError("Unrecognized action spec")
 
 
+def wrapper_type_from_ob_spec(ob_spec):
+    """Returns:
+      wrapper_type: str,
+        'image' or 'graph'
+      ob_dim: int
+    """
+    ob_name = getattr(ob_spec, 'name', None)
+
+    if ob_name == 'AgentCamera':
+        wrapper_type = 'image'
+        ob_dim = ob_spec.shape  # (64, 64, 3)
+    elif ob_name is None and 'nodes' in ob_spec:
+        wrapper_type = 'graph'
+        ob_dim = ob_spec['nodes'].shape[1] # 18 for all tasks except marble run
+    else:
+        raise ValueError("Unrecognized observation spec")
+
+    return wrapper_type, ob_dim
+
+
 class ActorCritic(nn.Module):
 
     def __init__(self, ob_spec, ac_spec):
         super().__init__()
 
-        assert 'nodes' in ob_spec, \
-            "Only graph obs supported"
-
-        obs_dim = ob_spec["nodes"].shape[1]  # 18 for all tasks except marble run
-        ac_spec_type = wrapper_type_from_ac_spec(ac_spec)
+        ob_type, ob_dim = wrapper_type_from_ob_spec(ob_spec)
+        ac_type = wrapper_type_from_ac_spec(ac_spec)
 
         # TODO: assertion for ac_spec dimension
 
         # policy builder depends on action space
-        if ac_spec_type == 'continuous_absolute':
-            self.ac = MLPGaussianActorCritic(obs_dim=obs_dim,
+        if ac_type == 'continuous_absolute':
+            embed_size = 256 if ob_type == 'graph' else None
+            self.ac = MLPGaussianActorCritic(obs_dim=ob_dim,
                                              act_dim=4,
-                                             rnn_hidden_size=256,
-                                             mlp_hidden_size=256)
+                                             ob_type=ob_type,
+                                             mlp_hidden_size=256,
+                                             encoder_embedding_size=embed_size)
         else:
-            raise NotImplementedError
+            raise NotImplementedError(f"Model does not support {ac_type} actions")
 
     def step(self, obs):
         with torch.no_grad():
-            _, obs_embed = self.ac.rnn_encoder(obs)
+            obs_embed = self.ac.encoder(obs)
             pi = self.ac._distribution(obs_embed)
             a = pi.sample()
             logp_a = self.ac._log_prob_from_distribution(pi, a)


### PR DESCRIPTION
- `MLPGaussicanActorCritic` supports both graph observations (with `RNNEncoder`) and image observations (with `CNNEncoder`)
- Update model rollout script to support both mixed wrapper and `continuous_absolute` wrapper