### PR TITLE
Rescale action

### DIFF
--- a/experiments/ppo.py
+++ b/experiments/ppo.py
@@ -333,6 +333,11 @@ def ppo(task, actor_critic=model.ActorCritic, ac_kwargs=dict(), seed=0,
             # save and log
             buf.store(timestep.observation, a, r, v, logp)
             logger.store(VVals=v)
+
+            # TODO debugging
+            logger.store(AHor=a[0])
+            logger.store(AVer=a[1])
+            logger.store(ASel=a[3])
             
             # Update obs (critical!)
             timestep = next_timestep
@@ -378,6 +383,11 @@ def ppo(task, actor_critic=model.ActorCritic, ac_kwargs=dict(), seed=0,
         logger.log_tabular('ClipFrac', average_only=True)
         logger.log_tabular('StopIter', average_only=True)
         logger.log_tabular('Time', time.time()-start_time)
+
+        # TODO debugging
+        logger.log_tabular('AHor', with_min_and_max=True)
+        logger.log_tabular('AVer', with_min_and_max=True)
+        logger.log_tabular('ASel', with_min_and_max=True)
 
         # Save model
         if (epoch % save_freq == 0 and epoch > 0) or (epoch == epochs-1):

--- a/experiments/ppo.py
+++ b/experiments/ppo.py
@@ -119,7 +119,8 @@ class PPOBuffer:
 def ppo(task, actor_critic=model.ActorCritic, ac_kwargs=dict(), seed=0, 
         steps_per_epoch=4000, epochs=50, gamma=0.99, clip_ratio=0.2, lr=3e-4,
         v_loss_coeff=0.5, train_iters=80, lam=0.97, max_ep_len=1000,
-        target_kl=0.01, logger_kwargs=dict(), save_freq=10, wrapper_type="continuous_absolute"):
+        target_kl=0.01, logger_kwargs=dict(), save_freq=10, wrapper_type="continuous_absolute",
+        log_wandb=False):
     """
     Proximal Policy Optimization (by clipping), 
 
@@ -396,7 +397,7 @@ def ppo(task, actor_critic=model.ActorCritic, ac_kwargs=dict(), seed=0,
         if (epoch % save_freq == 0 and epoch > 0) or (epoch == epochs-1):
             logger.save_state({'env': env}, None)
 
-            if proc_id()==0:
+            if proc_id()==0 and log_wandb:
                 # Save the model parameters to wandb every save_freq epoch
                 # instead of waiting till the end
                 state = {
@@ -409,7 +410,7 @@ def ppo(task, actor_critic=model.ActorCritic, ac_kwargs=dict(), seed=0,
                 state_fname = os.path.join(wandb.run.dir, "state_dict.pt")
                 torch.save(state, state_fname)
 
-        if proc_id()==0:
+        if proc_id()==0 and log_wandb:
             wandb.log(logger.log_current_row, step=epoch)
         logger.dump_tabular()
 
@@ -429,12 +430,13 @@ if __name__ == '__main__':
     parser.add_argument('--exp_name', type=str, default='ppo')
     parser.add_argument('--hid', type=int, default=64)
     parser.add_argument('--embed_sz', type=int, default=64)
+    parser.add_argument('--log-wandb', help="log to wandb", action="store_true", default=False)
 
     args = parser.parse_args()
 
     mpi_fork(args.cpu)  # run parallel code with mpi
 
-    if proc_id() == 0:
+    if proc_id() == 0 and args.log_wandb:
         wandb_run_name = args.task + '-' + time.strftime("%Y%m%d_%H%M")
         wandb.init(project="dmc",
                    name=wandb_run_name,
@@ -446,4 +448,4 @@ if __name__ == '__main__':
     ppo(task=args.task, actor_critic=model.ActorCritic,
         ac_kwargs=dict(mlp_hidden_size=args.hid, embed_size=args.embed_sz), gamma=args.gamma, 
         seed=args.seed, steps_per_epoch=args.steps_per_epoch, epochs=args.epochs,
-        logger_kwargs=logger_kwargs, save_freq=args.save_freq)
+        logger_kwargs=logger_kwargs, save_freq=args.save_freq, log_wandb=args.log_wandb)

--- a/experiments/ppo.py
+++ b/experiments/ppo.py
@@ -324,7 +324,7 @@ def ppo(task, actor_critic=model.ActorCritic, ac_kwargs=dict(), seed=0,
         for t in range(local_steps_per_epoch):
             a, v, logp = ac.step(timestep.observation)
 
-            next_timestep = env.step(ac.action_to_dict(a))
+            next_timestep = env.step(ac.action_to_dict(a, rescale=True))
             r = timestep.reward
             d = next_timestep.last()  # TODO: check if r, d are assoc w/ correct timestep
             ep_ret += r
@@ -391,11 +391,10 @@ def ppo(task, actor_critic=model.ActorCritic, ac_kwargs=dict(), seed=0,
                     'ac_state_dict': ac.ac.state_dict(),
                     'optimizer': optimizer.state_dict(),
                 }
-                # hack for wandb: should output the model in the wandb.run.dir to avoid
-                # problems syncing the model in the cloud with wandb's files
+                # output the model in the wandb.run.dir to avoid problems
+                # syncing the model in the cloud with wandb's files
                 state_fname = os.path.join(wandb.run.dir, "state_dict.pt")
                 torch.save(state, state_fname)
-                #wandb.save(state_fname)
 
         if proc_id()==0:
             wandb.log(logger.log_current_row, step=epoch)


### PR DESCRIPTION
- Rescale RGB image observations to [0, 1]
- Rescale (continuous) actions for continuous_absolute env wrapper


TODOs
- images don't include a 4th (x,y) coordinate channel as mentioned in Bapst paper appendix.
- add entropy bonus to loss